### PR TITLE
Support no argument init for wrapped values

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     name: "RestfulPropertyKit",
     platforms: [
         .iOS(.v14),
-        .macOS(.v10_15)
+        .macOS(.v11)
     ],
     products: [
         .library(

--- a/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
+++ b/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
@@ -667,6 +667,41 @@ public struct RestBearerType: Codable {
         }
     }
 
+    /// Implicitly used computed property for `@propertyWrapper`.
+    ///
+    /// Provides access to the associated query. Visibility is set to `fileprivate` to restrict
+    /// query mutations.
+    ///
+    /// Usage:
+    /// ~~~
+    /// struct Fruit: Codable {
+    ///     let name: String
+    ///     let size: Int
+    ///     let color: String
+    /// }
+    ///
+    /// ...
+    ///
+    /// @Rest(path: "fruitoftheday") var fruit: Fruit = Fruit(name: "strawberry", size: 3, color: "red")
+    ///
+    /// ...
+    ///
+    /// print($fruit) // projectedValue (aka query) access
+    ///
+    /// print($fruit.projectedValue) // nested projectedValue (aka binding) access
+    /// print($fruit.name) // nested projectedValue (aka binding) property (aka property binding) access
+    /// ~~~
+    ///
+    /// - Since: Sprint 1
+    public var projectedValue: RestQueryImpl<Parent, Value> {
+        get {
+            query
+        }
+        set {
+            query = newValue
+        }
+    }
+
     /// Creates a *Rest* property wrapper instance.
     ///
     /// Usage:
@@ -751,41 +786,6 @@ public struct RestBearerType: Codable {
     public init<ParamKey, ParamValue>(wrappedValue: Value, path: String, params: [ParamKey: ParamValue], bearer: Bool = true, parent: Parent.Type, prop: KeyPath<Parent, Value>) where ParamKey: CustomStringConvertible, ParamValue: CustomStringConvertible, Parent: ParentCodable, Parent.ChildCodable == Value {
         self._wrappedValue = RestMutableValueReference(value: wrappedValue)
         self.query = RestQueryImpl(self._wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path, params: Dictionary(uniqueKeysWithValues: params.map { (key: $0.key.description, value: $0.value.description) })), bearer: bearer, parent: parent, prop: prop))
-    }
-
-    /// Implicitly used computed property for `@propertyWrapper`.
-    ///
-    /// Provides access to the associated query. Visibility is set to `fileprivate` to restrict
-    /// query mutations.
-    ///
-    /// Usage:
-    /// ~~~
-    /// struct Fruit: Codable {
-    ///     let name: String
-    ///     let size: Int
-    ///     let color: String
-    /// }
-    ///
-    /// ...
-    ///
-    /// @Rest(path: "fruitoftheday") var fruit: Fruit = Fruit(name: "strawberry", size: 3, color: "red")
-    ///
-    /// ...
-    ///
-    /// print($fruit) // projectedValue (aka query) access
-    ///
-    /// print($fruit.projectedValue) // nested projectedValue (aka binding) access
-    /// print($fruit.name) // nested projectedValue (aka binding) property (aka property binding) access
-    /// ~~~
-    ///
-    /// - Since: Sprint 1
-    public var projectedValue: RestQueryImpl<Parent, Value> {
-        get {
-            query
-        }
-        set {
-            query = newValue
-        }
     }
 }
 

--- a/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
+++ b/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
@@ -182,6 +182,7 @@ public final class RestMutableValueReference<Value>: RestValueReference<Value> {
     /// - Since: Sprint 1
     public func update(with value: Value) {
         self.value = value
+        internalDebugPrint("Update Internal Reference for: ", value)
         self.objectWillChange.send()
     }
 }

--- a/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
+++ b/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
@@ -182,6 +182,7 @@ public final class RestMutableValueReference<Value>: RestValueReference<Value> {
     /// - Since: Sprint 1
     public func update(with value: Value) {
         self.value = value
+        self.objectWillChange.send()
     }
 }
 

--- a/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
+++ b/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
@@ -629,7 +629,7 @@ public struct RestBearerType: Codable {
 /// - Since: Sprint 1
 @propertyWrapper public struct Rest<Parent, Value>: DynamicProperty where Parent: Codable, Value: Codable {
     /// The mutable reference to the wrapped property value.
-    @StateObject private var _wrappedValue: RestMutableValueReference<Value>
+    private var _wrappedValue: RestMutableValueReference<Value>
     /// The query associated with this wrapped property.
     private var query: RestQueryImpl<Parent, Value>
 
@@ -681,8 +681,8 @@ public struct RestBearerType: Codable {
     ///
     /// - Since: Sprint 1
     public init(wrappedValue: Value, path: String, bearer: Bool = true) where Parent == Value {
-        self.__wrappedValue = StateObject(wrappedValue: RestMutableValueReference(value: wrappedValue))
-        self.query = RestQueryImpl(self.__wrappedValue.wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path), bearer: bearer, parent: Parent.self, prop: \Value.self))
+        self._wrappedValue = RestMutableValueReference(value: wrappedValue)
+        self.query = RestQueryImpl(self._wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path), bearer: bearer, parent: Parent.self, prop: \Value.self))
     }
 
     /// Creates a *Rest* property wrapper instance.
@@ -702,8 +702,8 @@ public struct RestBearerType: Codable {
     ///
     /// - Since: Sprint 1
     public init<ParamKey, ParamValue>(wrappedValue: Value, path: String, params: [ParamKey: ParamValue], bearer: Bool = true) where Parent == Value, ParamKey: CustomStringConvertible, ParamValue: CustomStringConvertible {
-        self.__wrappedValue = StateObject(wrappedValue: RestMutableValueReference(value: wrappedValue))
-        self.query = RestQueryImpl(self.__wrappedValue.wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path, params: Dictionary(uniqueKeysWithValues: params.map { (key: $0.key.description, value: $0.value.description) })), bearer: bearer, parent: Parent.self, prop: \Value.self))
+        self._wrappedValue = RestMutableValueReference(value: wrappedValue)
+        self.query = RestQueryImpl(self._wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path, params: Dictionary(uniqueKeysWithValues: params.map { (key: $0.key.description, value: $0.value.description) })), bearer: bearer, parent: Parent.self, prop: \Value.self))
     }
 
     /// Creates a *Rest* property wrapper instance.
@@ -724,8 +724,8 @@ public struct RestBearerType: Codable {
     ///
     /// - Since: Sprint 1
     public init(wrappedValue: Value, path: String, bearer: Bool = true, parent: Parent.Type, prop: KeyPath<Parent, Value>) where Parent: ParentCodable, Parent.ChildCodable == Value {
-        self.__wrappedValue = StateObject(wrappedValue: RestMutableValueReference(value: wrappedValue))
-        self.query = RestQueryImpl(self.__wrappedValue.wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path), bearer: bearer, parent: parent, prop: prop))
+        self._wrappedValue = RestMutableValueReference(value: wrappedValue)
+        self.query = RestQueryImpl(self._wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path), bearer: bearer, parent: parent, prop: prop))
     }
 
     /// Creates a *Rest* property wrapper instance.
@@ -747,8 +747,8 @@ public struct RestBearerType: Codable {
     ///
     /// - Since: Sprint 1
     public init<ParamKey, ParamValue>(wrappedValue: Value, path: String, params: [ParamKey: ParamValue], bearer: Bool = true, parent: Parent.Type, prop: KeyPath<Parent, Value>) where ParamKey: CustomStringConvertible, ParamValue: CustomStringConvertible, Parent: ParentCodable, Parent.ChildCodable == Value {
-        self.__wrappedValue = StateObject(wrappedValue: RestMutableValueReference(value: wrappedValue))
-        self.query = RestQueryImpl(self.__wrappedValue.wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path, params: Dictionary(uniqueKeysWithValues: params.map { (key: $0.key.description, value: $0.value.description) })), bearer: bearer, parent: parent, prop: prop))
+        self._wrappedValue = RestMutableValueReference(value: wrappedValue)
+        self.query = RestQueryImpl(self._wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path, params: Dictionary(uniqueKeysWithValues: params.map { (key: $0.key.description, value: $0.value.description) })), bearer: bearer, parent: parent, prop: prop))
     }
 
     /// Implicitly used computed property for `@propertyWrapper`.

--- a/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
+++ b/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
@@ -26,6 +26,9 @@ import Security
 import Combine
 import SwiftUI
 
+/// Opt-in conformance for structures with no argument initializer.
+///
+/// - Since: Sprint 2
 public protocol NoArgInit {
     init()
 }

--- a/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
+++ b/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
@@ -140,11 +140,11 @@ public extension ParentCodable {
 /// property wrapper to internal logic, requiring a reference to the value even if it is a struct or enum.
 ///
 /// - Since: Sprint 1
-public class RestValueReference<Value>: ObservableObject {
+public class RestValueReference<Value> {
     /// The referenced value. Visibility is set to `fileprivate` to allow the implementation of
     /// `RestMutableValueReference<Value>` while restricting other subclasses from modifying
     /// the referenced value.
-    @Published fileprivate(set) var value: Value
+    fileprivate(set) var value: Value
 
     /// Returns a new instance of *RestValueReference* containing a value of type `Value`.
     ///
@@ -185,9 +185,8 @@ public final class RestMutableValueReference<Value>: RestValueReference<Value> {
     ///
     /// - Since: Sprint 1
     public func update(with value: Value) {
-        self.value = value
         internalDebugPrint("Update Internal Reference for: ", value)
-        self.objectWillChange.send()
+        self.value = value
     }
 }
 
@@ -633,7 +632,7 @@ public struct RestBearerType: Codable {
 /// - Requires: The parent type `Parent` and the value type `Value` must conform to protocol `Codable`.
 ///
 /// - Since: Sprint 1
-@propertyWrapper public struct Rest<Parent, Value>: DynamicProperty where Parent: Codable, Value: Codable {
+@propertyWrapper public struct Rest<Parent, Value> where Parent: Codable, Value: Codable {
     /// The mutable reference to the wrapped property value.
     private var _wrappedValue: RestMutableValueReference<Value>
     /// The query associated with this wrapped property.

--- a/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
+++ b/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
@@ -28,6 +28,16 @@ import SwiftUI
 
 /// Opt-in conformance for structures with no argument initializer.
 ///
+/// Example:
+/// ~~~
+/// struct Account: Codable, NoArgInit {
+///     // The account email.
+///     var email: String = ""
+///     // The account password.
+///     var password: String = ""
+/// }
+/// ~~~
+///
 /// - Since: Sprint 2
 public protocol NoArgInit {
     init()

--- a/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
+++ b/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
@@ -26,6 +26,10 @@ import Security
 import Combine
 import SwiftUI
 
+public protocol NoArgInit {
+    init()
+}
+
 /// A type that can wrap a child *Codable* value into a representation of itself.
 ///
 /// Protocol *ParentCodable* can only be used as a generic constraint because it has
@@ -785,6 +789,90 @@ public struct RestBearerType: Codable {
     /// - Since: Sprint 1
     public init<ParamKey, ParamValue>(wrappedValue: Value, path: String, params: [ParamKey: ParamValue], bearer: Bool = true, parent: Parent.Type, prop: KeyPath<Parent, Value>) where ParamKey: CustomStringConvertible, ParamValue: CustomStringConvertible, Parent: ParentCodable, Parent.ChildCodable == Value {
         self._wrappedValue = RestMutableValueReference(value: wrappedValue)
+        self.query = RestQueryImpl(self._wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path, params: Dictionary(uniqueKeysWithValues: params.map { (key: $0.key.description, value: $0.value.description) })), bearer: bearer, parent: parent, prop: prop))
+    }
+}
+
+extension Rest where Value: NoArgInit {
+    /// Creates a *Rest* property wrapper instance.
+    ///
+    /// Usage:
+    /// ~~~
+    /// @Rest(path: "somePath") var someProp: SomeType
+    /// ~~~
+    ///
+    /// - Parameters:
+    ///   - path: The url request path component.
+    ///   - bearer: True if the bearer token should be send as part of the request.
+    ///
+    /// - Returns: A new *Rest* property wrapper instance.
+    ///
+    /// - Since: Sprint 1
+    public init(path: String, bearer: Bool = true) where Parent == Value {
+        self._wrappedValue = RestMutableValueReference(value: Value.init())
+        self.query = RestQueryImpl(self._wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path), bearer: bearer, parent: Parent.self, prop: \Value.self))
+    }
+
+    /// Creates a *Rest* property wrapper instance.
+    ///
+    /// Usage:
+    /// ~~~
+    /// @Rest(path: "somePath", params: ["someKey": someValue]) var someProp: SomeType
+    /// ~~~
+    ///
+    /// - Parameters:
+    ///   - path: The url request path component.
+    ///   - params: The url request query parameter component.
+    ///   - bearer: True if the bearer token should be send as part of the request.
+    ///
+    /// - Returns: A new *Rest* property wrapper instance.
+    ///
+    /// - Since: Sprint 1
+    public init<ParamKey, ParamValue>(path: String, params: [ParamKey: ParamValue], bearer: Bool = true) where Parent == Value, ParamKey: CustomStringConvertible, ParamValue: CustomStringConvertible {
+        self._wrappedValue = RestMutableValueReference(value: Value.init())
+        self.query = RestQueryImpl(self._wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path, params: Dictionary(uniqueKeysWithValues: params.map { (key: $0.key.description, value: $0.value.description) })), bearer: bearer, parent: Parent.self, prop: \Value.self))
+    }
+
+    /// Creates a *Rest* property wrapper instance.
+    ///
+    /// Usage:
+    /// ~~~
+    /// @Rest(path: "somePath", parent: SomeParentType.self, prop: \.somePropKey) var someProp: SomeType
+    /// ~~~
+    ///
+    /// - Parameters:
+    ///   - path: The url request path component.
+    ///   - bearer: True if the bearer token should be send as part of the request.
+    ///   - parent: The parent type conforming to the `ParentCodable` protocol.
+    ///   - prop: The property to be extracted from the parent type.
+    ///
+    /// - Returns: A new *Rest* property wrapper instance.
+    ///
+    /// - Since: Sprint 1
+    public init(path: String, bearer: Bool = true, parent: Parent.Type, prop: KeyPath<Parent, Value>) where Parent: ParentCodable, Parent.ChildCodable == Value {
+        self._wrappedValue = RestMutableValueReference(value: Value.init())
+        self.query = RestQueryImpl(self._wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path), bearer: bearer, parent: parent, prop: prop))
+    }
+
+    /// Creates a *Rest* property wrapper instance.
+    ///
+    /// Usage:
+    /// ~~~
+    /// @Rest(path: "somePath", params: ["someKey": someValue], parent: SomeParentType.self, prop: \.somePropKey) var someProp: SomeType
+    /// ~~~
+    ///
+    /// - Parameters:
+    ///   - path: The url request path component.
+    ///   - params: The url request query parameter component.
+    ///   - bearer: True if the bearer token should be send as part of the request.
+    ///   - parent: The parent type conforming to the `ParentCodable` protocol.
+    ///   - prop: The property to be extracted from the parent type.
+    ///
+    /// - Returns: A new *Rest* property wrapper instance.
+    ///
+    /// - Since: Sprint 1
+    public init<ParamKey, ParamValue>(path: String, params: [ParamKey: ParamValue], bearer: Bool = true, parent: Parent.Type, prop: KeyPath<Parent, Value>) where ParamKey: CustomStringConvertible, ParamValue: CustomStringConvertible, Parent: ParentCodable, Parent.ChildCodable == Value {
+        self._wrappedValue = RestMutableValueReference(value: Value.init())
         self.query = RestQueryImpl(self._wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path, params: Dictionary(uniqueKeysWithValues: params.map { (key: $0.key.description, value: $0.value.description) })), bearer: bearer, parent: parent, prop: prop))
     }
 }

--- a/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
+++ b/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
@@ -136,11 +136,11 @@ public extension ParentCodable {
 /// property wrapper to internal logic, requiring a reference to the value even if it is a struct or enum.
 ///
 /// - Since: Sprint 1
-public class RestValueReference<Value> {
+public class RestValueReference<Value>: ObservableObject {
     /// The referenced value. Visibility is set to `fileprivate` to allow the implementation of
     /// `RestMutableValueReference<Value>` while restricting other subclasses from modifying
     /// the referenced value.
-    fileprivate(set) var value: Value
+    @Published fileprivate(set) var value: Value
 
     /// Returns a new instance of *RestValueReference* containing a value of type `Value`.
     ///
@@ -627,9 +627,9 @@ public struct RestBearerType: Codable {
 /// - Requires: The parent type `Parent` and the value type `Value` must conform to protocol `Codable`.
 ///
 /// - Since: Sprint 1
-@propertyWrapper public struct Rest<Parent, Value> where Parent: Codable, Value: Codable {
+@propertyWrapper public struct Rest<Parent, Value>: DynamicProperty where Parent: Codable, Value: Codable {
     /// The mutable reference to the wrapped property value.
-    private var _wrappedValue: RestMutableValueReference<Value>
+    @StateObject private var _wrappedValue: RestMutableValueReference<Value>
     /// The query associated with this wrapped property.
     private var query: RestQueryImpl<Parent, Value>
 
@@ -681,8 +681,8 @@ public struct RestBearerType: Codable {
     ///
     /// - Since: Sprint 1
     public init(wrappedValue: Value, path: String, bearer: Bool = true) where Parent == Value {
-        self._wrappedValue = RestMutableValueReference(value: wrappedValue)
-        self.query = RestQueryImpl(self._wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path), bearer: bearer, parent: Parent.self, prop: \Value.self))
+        self.__wrappedValue = StateObject(wrappedValue: RestMutableValueReference(value: wrappedValue))
+        self.query = RestQueryImpl(self.__wrappedValue.wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path), bearer: bearer, parent: Parent.self, prop: \Value.self))
     }
 
     /// Creates a *Rest* property wrapper instance.
@@ -702,8 +702,8 @@ public struct RestBearerType: Codable {
     ///
     /// - Since: Sprint 1
     public init<ParamKey, ParamValue>(wrappedValue: Value, path: String, params: [ParamKey: ParamValue], bearer: Bool = true) where Parent == Value, ParamKey: CustomStringConvertible, ParamValue: CustomStringConvertible {
-        self._wrappedValue = RestMutableValueReference(value: wrappedValue)
-        self.query = RestQueryImpl(self._wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path, params: Dictionary(uniqueKeysWithValues: params.map { (key: $0.key.description, value: $0.value.description) })), bearer: bearer, parent: Parent.self, prop: \Value.self))
+        self.__wrappedValue = StateObject(wrappedValue: RestMutableValueReference(value: wrappedValue))
+        self.query = RestQueryImpl(self.__wrappedValue.wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path, params: Dictionary(uniqueKeysWithValues: params.map { (key: $0.key.description, value: $0.value.description) })), bearer: bearer, parent: Parent.self, prop: \Value.self))
     }
 
     /// Creates a *Rest* property wrapper instance.
@@ -724,8 +724,8 @@ public struct RestBearerType: Codable {
     ///
     /// - Since: Sprint 1
     public init(wrappedValue: Value, path: String, bearer: Bool = true, parent: Parent.Type, prop: KeyPath<Parent, Value>) where Parent: ParentCodable, Parent.ChildCodable == Value {
-        self._wrappedValue = RestMutableValueReference(value: wrappedValue)
-        self.query = RestQueryImpl(self._wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path), bearer: bearer, parent: parent, prop: prop))
+        self.__wrappedValue = StateObject(wrappedValue: RestMutableValueReference(value: wrappedValue))
+        self.query = RestQueryImpl(self.__wrappedValue.wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path), bearer: bearer, parent: parent, prop: prop))
     }
 
     /// Creates a *Rest* property wrapper instance.
@@ -747,8 +747,8 @@ public struct RestBearerType: Codable {
     ///
     /// - Since: Sprint 1
     public init<ParamKey, ParamValue>(wrappedValue: Value, path: String, params: [ParamKey: ParamValue], bearer: Bool = true, parent: Parent.Type, prop: KeyPath<Parent, Value>) where ParamKey: CustomStringConvertible, ParamValue: CustomStringConvertible, Parent: ParentCodable, Parent.ChildCodable == Value {
-        self._wrappedValue = RestMutableValueReference(value: wrappedValue)
-        self.query = RestQueryImpl(self._wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path, params: Dictionary(uniqueKeysWithValues: params.map { (key: $0.key.description, value: $0.value.description) })), bearer: bearer, parent: parent, prop: prop))
+        self.__wrappedValue = StateObject(wrappedValue: RestMutableValueReference(value: wrappedValue))
+        self.query = RestQueryImpl(self.__wrappedValue.wrappedValue, RestQueryMetadata(urlComponents: RestURLComponents(path: path, params: Dictionary(uniqueKeysWithValues: params.map { (key: $0.key.description, value: $0.value.description) })), bearer: bearer, parent: parent, prop: prop))
     }
 
     /// Implicitly used computed property for `@propertyWrapper`.

--- a/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
+++ b/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
@@ -659,10 +659,10 @@ public struct RestBearerType: Codable {
     ///
     /// - Since: Sprint 1
     public var wrappedValue: Value {
-        get {
+        nonmutating get {
             _wrappedValue.value
         }
-        set {
+        nonmutating set {
             _wrappedValue.update(with: newValue)
         }
     }

--- a/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
+++ b/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
@@ -40,6 +40,7 @@ import SwiftUI
 ///
 /// - Since: Sprint 2
 public protocol NoArgInit {
+    /// The required initializer with no argument.
     init()
 }
 

--- a/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
+++ b/Sources/RestfulPropertyKit/RestfulPropertyKit.swift
@@ -646,11 +646,25 @@ public struct RestBearerType: Codable {
     /// The mutable reference to the wrapped property value.
     @StateObject private var _wrappedValue = RestMutableValueReference<Value>()
     /// The query associated with this wrapped property.
-    private lazy var query: RestQueryImpl<Parent, Value> = {
-        RestQueryImpl(self._wrappedValue, self.queryMetadata)
-    }()
+    private var query: LazyQueryConstruction!
 
     private var queryMetadata: RestQueryMetadata<Parent, Value>
+
+    /*private lazy var query: RestQueryImpl<Parent, Value> = {
+     RestQueryImpl(self._wrappedValue, self.queryMetadata)
+     }()*/
+
+    private class LazyQueryConstruction {
+        private let constructor: (() -> RestQueryImpl<Parent, Value>)
+
+        init(constructor: @escaping () -> RestQueryImpl<Parent, Value>) {
+            self.constructor = constructor
+        }
+
+        fileprivate lazy var constructed: RestQueryImpl<Parent, Value> = {
+            self.constructor()
+        }()
+    }
 
     /// Implicitly used computed property for `@propertyWrapper`.
     ///
@@ -701,6 +715,7 @@ public struct RestBearerType: Codable {
     /// - Since: Sprint 1
     public init(wrappedValue: Value, path: String, bearer: Bool = true) where Parent == Value {
         self.queryMetadata = RestQueryMetadata(urlComponents: RestURLComponents(path: path), bearer: bearer, parent: Parent.self, prop: \Value.self)
+        self.query = LazyQueryConstruction(constructor: self.constructQuery)
         self._wrappedValue.update(with: wrappedValue)
     }
 
@@ -722,6 +737,7 @@ public struct RestBearerType: Codable {
     /// - Since: Sprint 1
     public init<ParamKey, ParamValue>(wrappedValue: Value, path: String, params: [ParamKey: ParamValue], bearer: Bool = true) where Parent == Value, ParamKey: CustomStringConvertible, ParamValue: CustomStringConvertible {
         self.queryMetadata = RestQueryMetadata(urlComponents: RestURLComponents(path: path, params: Dictionary(uniqueKeysWithValues: params.map { (key: $0.key.description, value: $0.value.description) })), bearer: bearer, parent: Parent.self, prop: \Value.self)
+        self.query = LazyQueryConstruction(constructor: self.constructQuery)
         self._wrappedValue.update(with: wrappedValue)
     }
 
@@ -744,6 +760,7 @@ public struct RestBearerType: Codable {
     /// - Since: Sprint 1
     public init(wrappedValue: Value, path: String, bearer: Bool = true, parent: Parent.Type, prop: KeyPath<Parent, Value>) where Parent: ParentCodable, Parent.ChildCodable == Value {
         self.queryMetadata = RestQueryMetadata(urlComponents: RestURLComponents(path: path), bearer: bearer, parent: parent, prop: prop)
+        self.query = LazyQueryConstruction(constructor: self.constructQuery)
         self._wrappedValue.update(with: wrappedValue)
     }
 
@@ -767,7 +784,12 @@ public struct RestBearerType: Codable {
     /// - Since: Sprint 1
     public init<ParamKey, ParamValue>(wrappedValue: Value, path: String, params: [ParamKey: ParamValue], bearer: Bool = true, parent: Parent.Type, prop: KeyPath<Parent, Value>) where ParamKey: CustomStringConvertible, ParamValue: CustomStringConvertible, Parent: ParentCodable, Parent.ChildCodable == Value {
         self.queryMetadata = RestQueryMetadata(urlComponents: RestURLComponents(path: path, params: Dictionary(uniqueKeysWithValues: params.map { (key: $0.key.description, value: $0.value.description) })), bearer: bearer, parent: parent, prop: prop)
+        self.query = LazyQueryConstruction(constructor: self.constructQuery)
         self._wrappedValue.update(with: wrappedValue)
+    }
+
+    private func constructQuery() -> RestQueryImpl<Parent, Value> {
+        RestQueryImpl(self._wrappedValue, self.queryMetadata)
     }
 
     /// Implicitly used computed property for `@propertyWrapper`.
@@ -797,8 +819,8 @@ public struct RestBearerType: Codable {
     ///
     /// - Since: Sprint 1
     public var projectedValue: RestQueryImpl<Parent, Value> {
-        mutating get {
-            query
+        get {
+            query.constructed
         }
     }
 }


### PR DESCRIPTION
# Description

Reduce:

```swift
@Rest(path: "signup", bearer: false) private var signUp: Account = Account()
```

to

```swift
@Rest(path: "signup", bearer: false) private var signUp: Account
```

if `Account` conforms to `NoArgInit`.

## Checklist

### Management

- [x] Link Issue
- [x] Add Description
- [x] Assign Sprint
- [x] Assign Moscow Prioritization

### Implementation

- [x] Possible Optimizations
- [x] Convention Usage

### Documentation

- [x] Constructs (Structures, Classes, Extensions & Protocols)
- [x] Properties
- [x] Methods
- [x] Usage Examples

### Review

- [x] Assign Reviewer(s)
- [x] Complexity & Readability
- [x] Formatting
